### PR TITLE
import.rb: 絵文字追加ページの仕様変更に対応

### DIFF
--- a/scripts/import.rb
+++ b/scripts/import.rb
@@ -1,4 +1,5 @@
 require 'highline/import'
+require 'json'
 require 'mechanize'
 
 # Decomoji Importer
@@ -7,7 +8,7 @@ class Importer
     @page = nil
     @agent = Mechanize.new
   end
-  attr_accessor :page, :agent
+  attr_accessor :page, :agent, :team_name, :token
 
   def import_decomojis
     move_to_emoji_page
@@ -17,7 +18,7 @@ class Importer
   private
 
   def login
-    team_name  = ask('Your slack team name(subdomain): ')
+    @team_name = ask('Your slack team name(subdomain): ')
     email      = ask('Login email: ')
     password   = ask('Login password(hidden): ') { |q| q.echo = false }
 
@@ -27,6 +28,7 @@ class Importer
     page.form.email = email
     page.form.password = password
     @page = page.form.submit
+    @token = @page.body[/(?<=api_token:\s")[^"]+/]
   end
 
   def enter_two_factor_authentication_code
@@ -49,19 +51,35 @@ class Importer
   end
 
   def upload_decomojis
+    emojis = list_emojis
     Dir.glob(File.expand_path(File.dirname(__FILE__)) + "/../decomoji/basic/*.png").each do |path|
       basename = File.basename(path, '.*')
 
       # skip if already exists
-      next if page.body.include?(":#{basename}:")
+      next if emojis.include?(basename)
 
       puts "importing #{basename}..."
 
-      form = page.form_with(action: '/customize/emoji')
-      form['name'] = basename
-      form.file_upload.file_name = path
-      @page = form.submit
+      params = {
+        name: basename,
+        image: File.new(path),
+        mode: 'data',
+        token: token
+      }
+      agent.post("https://#{team_name}.slack.com/api/emoji.add", params)
     end
+  end
+
+  def list_emojis
+    emojis = []
+    loop.with_index(1) do |_, n|
+      params = { query: '', page: n, count: 100, token: token }
+      res = JSON.parse(agent.post("https://#{team_name}.slack.com/api/emoji.adminList", params).body)
+      raise res['error'] if res['error']
+      emojis.push(*res['emoji'].map { |e| e['name'] })
+      break if res['paging']['pages'] == n || res['paging']['pages'] == 0
+    end
+    emojis
   end
 end
 


### PR DESCRIPTION
`/customize/emoji` の仕様が変わり import.rb が動かなくなったので、動くように対応しました。

- `/customize/emoji` の HTML の中に `<form>` タグや `:#{emoji_name}:` が含まれなくなった
- POST 先が変わった (`/api/emoji.add`)

`emoji.add` の API はドキュメントも Permission も未公開のようなので、Mechanize で対応しています。
