### PR TITLE
Fix org name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/oti/slack-reaction-decomoji.git"
+    "url": "git+https://github.com/decomoji/slack-reaction-decomoji.git"
   },
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/oti/slack-reaction-decomoji/issues"
+    "url": "https://github.com/decomoji/slack-reaction-decomoji/issues"
   },
-  "homepage": "https://github.com/oti/slack-reaction-decomoji#readme"
+  "homepage": "https://github.com/decomoji/slack-reaction-decomoji#readme"
 }


### PR DESCRIPTION
It seems `oti/slack-reaction-decomoji` is renamed to `decomoji/slack-reaction-decomoji` .