### PR TITLE
エイリアスを登録する処理を import.rb に追加する

### DIFF
--- a/scripts/import.rb
+++ b/scripts/import.rb
@@ -4,8 +4,9 @@ require 'mechanize'
 
 # sample command
 #   - bundle exec ruby import.rb preview account.json
+#   - bundle exec ruby import.rb alias-standard.json account.json
 
 require './importer'
-importer = Importer.new(import_target: ARGV[0], account: ARGV[1])
+importer = Importer.new(import_target: ARGV[0], import_mode: ARGV[1], account: ARGV[2])
 importer.serial
 puts 'Done!'


### PR DESCRIPTION
```
[
  {
    "basename": "わかる",
    "alias_for": "wakaru"
  }
]
```

上記を `aliases.json` などとして `scripts/` ディレクトリ配下に保存し、

```
bundle exec ruby import.rb aliases.json alias
```

を実行することで `:わかる:` で `:wakaru:` をエイリアスで引き当てて利用できるようにするスクリプトを import.rb に追加した。