### PR TITLE
v5.15.1

### DIFF
--- a/configs/v5.15.1.json
+++ b/configs/v5.15.1.json
@@ -1,0 +1,1 @@
+{ "fixed": [], "upload": [], "rename": [] }

--- a/configs/v5_all.json
+++ b/configs/v5_all.json
@@ -27544,6 +27544,7 @@
     "created": "v5.0.0",
     "updated": "v5.14.1"
   },
+  { "name": "jojo", "path": "decomoji/extra/jojo.png", "created": "v5.15.0" },
   {
     "name": "jojoari",
     "path": "decomoji/extra/jojoari.png",

--- a/configs/v5_extra.json
+++ b/configs/v5_extra.json
@@ -26848,6 +26848,7 @@
     "created": "v5.0.0",
     "updated": "v5.14.1"
   },
+  { "name": "jojo", "path": "decomoji/extra/jojo.png", "created": "v5.15.0" },
   {
     "name": "jojoari",
     "path": "decomoji/extra/jojoari.png",

--- a/scripts/generator/toDiffJson.js
+++ b/scripts/generator/toDiffJson.js
@@ -21,7 +21,12 @@ const CATEGORY_INCLUDE_ITEMS = [
     created: "v5.15.0",
   },
 ];
-const RENAME_INCLUDE_ITEMS = [{ name: "euc_jp", alias_for: "euc-jp" }];
+const RENAME_INCLUDE_ITEMS = [
+  {
+    name: "euc_jp",
+    alias_for: "euc-jp",
+  },
+];
 const RENAME_EXCLUDE_ITEMS = ["nasca\\343\\201\\247", "joinsiyo", "zyoinsiyo"];
 
 // デコモジオブジェクトの格納先

--- a/scripts/generator/toDiffJson.js
+++ b/scripts/generator/toDiffJson.js
@@ -15,6 +15,11 @@ const CATEGORY_INCLUDE_ITEMS = [
     created: "v5.0.0",
     updated: "v5.14.1",
   },
+  {
+    name: "jojo",
+    path: "decomoji/extra/jojo.png",
+    created: "v5.15.0",
+  },
 ];
 const RENAME_INCLUDE_ITEMS = [{ name: "euc_jp", alias_for: "euc-jp" }];
 const RENAME_EXCLUDE_ITEMS = ["nasca\\343\\201\\247", "joinsiyo", "zyoinsiyo"];


### PR DESCRIPTION
`jojo` が configs/ の JSON に含まれないバグがあったので修正した。

バグというよりは、 `jojo` は過去のバージョンで `zyozyo` にリネームしていたが、v5.15 で `jojo` を再登録しており、toDiffJson.js でその整合性を取れていなかった。

git commit の種類であれこれして削除済みのファイルもバージョンごとの JSON に含めているものの、登録スクリプト用の JSON からは削除済みを除外する実装になっている。

これの対応はちょっとめんどくさいので、ハードコーディングで対応した。