### PR TITLE
v5.15.3

### DIFF
--- a/configs/v5.15.3.json
+++ b/configs/v5.15.3.json
@@ -1,0 +1,1 @@
+{ "fixed": [], "upload": [], "rename": [] }

--- a/configs/v5_rename.json
+++ b/configs/v5_rename.json
@@ -250,7 +250,6 @@
     "alias_for": "touzyouzinnbutuzenninnnoukinn"
   },
   { "name": "tourokusakujo", "alias_for": "tourokusakuzyo" },
-  { "name": "true false", "alias_for": "truefalse" },
   { "name": "tukaene-jane-ka", "alias_for": "tukaene-zyane-ka" },
   { "name": "unndounojuuyousei", "alias_for": "unndounozyuuyousei" },
   { "name": "unnkijousyou", "alias_for": "unnkizyousyou" },

--- a/scripts/generator/toDiffJson.js
+++ b/scripts/generator/toDiffJson.js
@@ -27,7 +27,12 @@ const RENAME_INCLUDE_ITEMS = [
     alias_for: "euc-jp",
   },
 ];
-const RENAME_EXCLUDE_ITEMS = ["nasca\\343\\201\\247", "joinsiyo", "zyoinsiyo"];
+const RENAME_EXCLUDE_ITEMS = [
+  "nasca\\343\\201\\247",
+  "joinsiyo",
+  "zyoinsiyo",
+  "true false",
+];
 
 // デコモジオブジェクトの格納先
 const Seeds = {

--- a/scripts/manager/modules/goToEmojiPage.js
+++ b/scripts/manager/modules/goToEmojiPage.js
@@ -54,7 +54,7 @@ const goToEmojiPage = async (page, inputs) => {
   // 「サインイン」する
   await Promise.all([
     page.click("#signin_btn"),
-    page.waitForSelector("#list_emoji_section"),
+    page.waitForNavigation({ waitUntil: ["load", "networkidle2"] }),
   ]);
   // ログインエラーになっているかをチェックする
   if (await page.$(".c-input_text--with_error").then((res) => !!res)) {
@@ -95,7 +95,7 @@ const goToEmojiPage = async (page, inputs) => {
         await page.type("#password", retry.password);
         await Promise.all([
           page.click("#signin_btn"),
-          page.waitForSelector("#list_emoji_section"),
+          page.waitForNavigation({ waitUntil: "networkidle2" }),
         ]);
         // #signin_form がなかったらログインできたと見なして再帰処理を抜ける
         if (await page.$("#signin_form").then((res) => !res)) {
@@ -133,7 +133,7 @@ const goToEmojiPage = async (page, inputs) => {
         await page.type('[name="2fa_code"]', twofactor_code);
         await Promise.all([
           page.click("#signin_btn"),
-          page.waitForSelector("#list_emoji_section"),
+          page.waitForNavigation({ waitUntil: "networkidle0" }),
         ]);
         // 2FA入力欄がなかったら2FA認証できたと見なして再帰処理を抜ける
         if (await page.$('[name="2fa_code"]').then((res) => !res)) {

--- a/scripts/manager/modules/goToEmojiPage.js
+++ b/scripts/manager/modules/goToEmojiPage.js
@@ -1,7 +1,3 @@
-const inquirer = require("inquirer");
-
-const isEmail = require("../../utilities/isEmail");
-const isInputs = require("../../utilities/isInputs");
 const recursiveInputWorkspace = require("./recursiveInputWorkspace");
 const recursiveInputAccount = require("./recursiveInputAccount");
 const recursiveInput2FA = require("./recursiveInput2FA");
@@ -22,19 +18,18 @@ const goToEmojiPage = async (browser, page, inputs) => {
   if (await page.$("#signin_form").then((res) => !res)) {
     inputs = await recursiveInputWorkspace(page, inputs);
   }
-  // Recaptcha があるかをチェックする
+
+  // CAPTCHA が出ていたら諦めて終了する
   if (await page.$("#slack_captcha").then((res) => !!res)) {
-    // Recaptcha があったら無理なので諦める
     console.error(
       "[ERROR]Oops, you might judged a bot. Please wait and try again."
     );
     await browser.close();
   }
-  // ログイン email を入力する
+
+  // email とパスワードを入力してサインインする
   await page.type("#email", inputs.email);
-  // パスワードを入力する
   await page.type("#password", inputs.password);
-  // 「サインイン」する
   await Promise.all([
     page.click("#signin_btn"),
     page.waitForNavigation({ waitUntil: ["load", "networkidle2"] }),

--- a/scripts/manager/modules/goToEmojiPage.js
+++ b/scripts/manager/modules/goToEmojiPage.js
@@ -3,7 +3,7 @@ const inquirer = require("inquirer");
 const isEmail = require("../../utilities/isEmail");
 const isInputs = require("../../utilities/isInputs");
 
-const goToEmojiPage = async (page, inputs) => {
+const goToEmojiPage = async (browser, page, inputs) => {
   const TIME = inputs.time;
 
   TIME && console.time("[Login time]");

--- a/scripts/manager/modules/goToEmojiPage.js
+++ b/scripts/manager/modules/goToEmojiPage.js
@@ -54,7 +54,7 @@ const goToEmojiPage = async (page, inputs) => {
   // 「サインイン」する
   await Promise.all([
     page.click("#signin_btn"),
-    page.waitForNavigation({ waitUntil: ["load", "networkidle2"] }),
+    page.waitForSelector("#list_emoji_section"),
   ]);
   // ログインエラーになっているかをチェックする
   if (await page.$(".alert_error").then((res) => !!res)) {
@@ -95,7 +95,7 @@ const goToEmojiPage = async (page, inputs) => {
         await page.type("#password", retry.password);
         await Promise.all([
           page.click("#signin_btn"),
-          page.waitForNavigation({ waitUntil: "networkidle0" }),
+          page.waitForSelector("#list_emoji_section"),
         ]);
         // #signin_form がなかったらログインできたと見なして再帰処理を抜ける
         if (await page.$("#signin_form").then((res) => !res)) {
@@ -133,7 +133,7 @@ const goToEmojiPage = async (page, inputs) => {
         await page.type('[name="2fa_code"]', twofactor_code);
         await Promise.all([
           page.click("#signin_btn"),
-          page.waitForNavigation({ waitUntil: "networkidle0" }),
+          page.waitForSelector("#list_emoji_section"),
         ]);
         // 2FA入力欄がなかったら2FA認証できたと見なして再帰処理を抜ける
         if (await page.$('[name="2fa_code"]').then((res) => !res)) {

--- a/scripts/manager/modules/goToEmojiPage.js
+++ b/scripts/manager/modules/goToEmojiPage.js
@@ -47,6 +47,14 @@ const goToEmojiPage = async (page, inputs) => {
     // 再帰処理をスタートする
     await _retry(inputs.workspace);
   }
+  // Recaptcha があるかをチェックする
+  if (await page.$("#slack_captcha").then((res) => !!res)) {
+    // Recaptcha があったら無理なので諦める
+    console.error(
+      "[ERROR]Oops, you might judged a bot. Please wait and try again."
+    );
+    await browser.close();
+  }
   // ログイン email を入力する
   await page.type("#email", inputs.email);
   // パスワードを入力する
@@ -87,7 +95,6 @@ const goToEmojiPage = async (page, inputs) => {
           );
           await browser.close();
         }
-
         // フォームに再入力して submit する
         const $email = await page.$("#email");
         await $email.click({ clickCount: 3 });
@@ -153,7 +160,6 @@ const goToEmojiPage = async (page, inputs) => {
     // 再帰処理をスタートする
     await _auth();
   }
-
   // グローバル変数 boot_data と、カスタム絵文字セクションが見つかるまで待つ
   await Promise.all([
     page.waitForXPath("//script[contains(text(), 'boot_data')]"),

--- a/scripts/manager/modules/goToEmojiPage.js
+++ b/scripts/manager/modules/goToEmojiPage.js
@@ -60,9 +60,6 @@ const goToEmojiPage = async (page, inputs) => {
   if (await page.$(".c-input_text--with_error").then((res) => !!res)) {
     // ログインエラーなら inquirer を起動して email と password を再入力させる
     const _retry = async (tried) => {
-      // 前の入力を空にしておく
-      await page.$eval("#email", (e) => (e.value = ""));
-      await page.$eval("#password", (e) => (e.value = ""));
       // ログイン試行
       try {
         const retry = await inquirer.prompt([
@@ -90,9 +87,14 @@ const goToEmojiPage = async (page, inputs) => {
           );
           await browser.close();
         }
+
         // フォームに再入力して submit する
-        await page.type("#email", retry.email);
-        await page.type("#password", retry.password);
+        const $email = await page.$("#email");
+        await $email.click({ clickCount: 3 });
+        await $email.type(retry.email);
+        const $password = await page.$("#password");
+        await $password.click({ clickCount: 3 });
+        await $password.type(retry.password);
         await Promise.all([
           page.click("#signin_btn"),
           page.waitForNavigation({ waitUntil: "networkidle2" }),

--- a/scripts/manager/modules/goToEmojiPage.js
+++ b/scripts/manager/modules/goToEmojiPage.js
@@ -57,7 +57,7 @@ const goToEmojiPage = async (page, inputs) => {
     page.waitForSelector("#list_emoji_section"),
   ]);
   // ログインエラーになっているかをチェックする
-  if (await page.$(".alert_error").then((res) => !!res)) {
+  if (await page.$(".c-input_text--with_error").then((res) => !!res)) {
     // ログインエラーなら inquirer を起動して email と password を再入力させる
     const _retry = async (tried) => {
       // 前の入力を空にしておく

--- a/scripts/manager/modules/pretender.js
+++ b/scripts/manager/modules/pretender.js
@@ -30,7 +30,7 @@ const pretender = async (inputs) => {
     const page = await browser.newPage();
 
     // カスタム絵文字管理画面へ遷移する
-    inputs = await goToEmojiPage(page, inputs);
+    inputs = await goToEmojiPage(browser, page, inputs);
 
     // ローカルのデコモジが存在しなかったらエラーにして終了する
     if (localDecomojiListLength === 0) {

--- a/scripts/manager/modules/pretender.js
+++ b/scripts/manager/modules/pretender.js
@@ -11,8 +11,6 @@ const pretender = async (inputs) => {
     debug: DEBUG,
     log: LOG,
     time: TIME,
-    twofactor_code: TWOFACTOR_CODE,
-    workspace: WORKSPACE,
   } = inputs;
 
   let i = 0; // 再帰でリストの続きから処理するためにインデックスを再帰関数の外に定義する
@@ -31,6 +29,9 @@ const pretender = async (inputs) => {
 
     // カスタム絵文字管理画面へ遷移する
     inputs = await goToEmojiPage(browser, page, inputs);
+
+    // 再入力されているかもしれないので取り直す
+    const { twofactor_code: TWOFACTOR_CODE, workspace: WORKSPACE } = inputs;
 
     // ローカルのデコモジが存在しなかったらエラーにして終了する
     if (localDecomojiListLength === 0) {

--- a/scripts/manager/modules/recursiveInput2FA.js
+++ b/scripts/manager/modules/recursiveInput2FA.js
@@ -1,0 +1,39 @@
+const inquirer = require("inquirer");
+const isInputs = require("../../utilities/isInputs");
+
+// 2FA利用時の再帰処理
+const recursiveInput2FA = async (browser, page, inputs) => {
+  // 前の入力を空にしておく
+  await page.$eval('[name="2fa_code"]', (e) => (e.value = ""));
+  // 2FA試行
+  try {
+    const { twofactor_code } = await inquirer.prompt({
+      type: "password",
+      name: "twofactor_code",
+      mask: "*",
+      message: "2FA コードを入力してください:",
+      validate: isInputs,
+    });
+    // 2FA 利用のフラグを立てる
+    inputs.twofactor_code = true;
+    // フォームに入力してサインインする
+    const $2fa = await page.$('[name="2fa_code"]');
+    await $2fa.click({ clickCount: 3 });
+    await $2fa.type(twofactor_code);
+    await Promise.all([
+      page.click("#signin_btn"),
+      page.waitForNavigation({ waitUntil: "networkidle2" }),
+    ]);
+    // 2FA入力欄がなかったら2FA認証できたと見なして再帰処理を抜ける
+    if (await page.$('[name="2fa_code"]').then((res) => !res)) {
+      console.info("2FA Verified!");
+      return inputs;
+    }
+    // 2FA認証できるまで何度でもトライ！
+    await recursiveInput2FA(browser, page, inputs);
+  } catch (e) {
+    return e;
+  }
+};
+
+module.exports = recursiveInput2FA;

--- a/scripts/manager/modules/recursiveInputAccount.js
+++ b/scripts/manager/modules/recursiveInputAccount.js
@@ -1,0 +1,59 @@
+const inquirer = require("inquirer");
+const isEmail = require("../../utilities/isEmail");
+const isInputs = require("../../utilities/isInputs");
+
+// ログインエラーの時の再帰処理
+const recursiveInputAccount = async (browser, page, inputs) => {
+  // ログイン試行
+  try {
+    const { email, password } = await inquirer.prompt([
+      {
+        type: "input",
+        name: "email",
+        message:
+          "ログインに失敗しました。正しいメールアドレスを入力してください:",
+        validate: isEmail,
+        default: inputs.email,
+      },
+      {
+        type: "password",
+        name: "password",
+        mask: "*",
+        message: "正しいパスワードを入力してください:",
+        validate: isInputs,
+      },
+    ]);
+    // email と password を保存し直す
+    inputs.email = email;
+    inputs.password = password;
+    // CAPTCHA が出ていたら諦めて終了する
+    if (await page.$("#slack_captcha").then((res) => !!res)) {
+      console.error(
+        "[ERROR]Oops, you might judged a bot. Please wait and try again."
+      );
+      await browser.close();
+    }
+    // フォームに再入力してサインインする
+    const $email = await page.$("#email");
+    await $email.click({ clickCount: 3 });
+    await $email.type(inputs.email);
+    const $password = await page.$("#password");
+    await $password.click({ clickCount: 3 });
+    await $password.type(inputs.password);
+    await Promise.all([
+      page.click("#signin_btn"),
+      page.waitForNavigation({ waitUntil: "networkidle2" }),
+    ]);
+    // #signin_form がなかったらログインできたと見なして再帰処理を抜ける
+    if (await page.$("#signin_form").then((res) => !res)) {
+      console.info("Login successful!");
+      return inputs;
+    }
+    // ログインできるまで何度でもトライ！
+    await recursiveInputAccount(browser, page, inputs);
+  } catch (e) {
+    return e;
+  }
+};
+
+module.exports = recursiveInputAccount;

--- a/scripts/manager/modules/recursiveInputWorkspace.js
+++ b/scripts/manager/modules/recursiveInputWorkspace.js
@@ -1,0 +1,33 @@
+const inquirer = require("inquirer");
+const isInputs = require("../../utilities/isInputs");
+
+// ワークスペースが見つからない時の再帰処理
+const recursiveInputWorkspace = async (page, inputs) => {
+  try {
+    const { workspace } = await inquirer.prompt({
+      type: "input",
+      name: "workspace",
+      message: `${inputs.workspace} は見つかりませんでした。ワークスペースを再度入力してください:`,
+      validate: isInputs,
+    });
+    // チーム名を保存し直す
+    inputs.workspace = workspace;
+    // ログイン画面に再び遷移する
+    await page.goto(
+      `https://${workspace}.slack.com/?redir=%2Fcustomize%2Femoji#/`,
+      {
+        waitUntil: "domcontentloaded",
+      }
+    );
+    // ログイン画面に遷移できたかを再びチェックし、できていたら再帰処理を抜ける
+    if (await page.$("#signin_form").then((res) => !!res)) {
+      return inputs;
+    }
+    // ログインページに到達できるまで何度でもトライ！
+    await recursiveInputWorkspace(page, inputs);
+  } catch (e) {
+    return e;
+  }
+};
+
+module.exports = recursiveInputWorkspace;

--- a/scripts/manager/modules/remover.js
+++ b/scripts/manager/modules/remover.js
@@ -11,8 +11,6 @@ const remover = async (inputs) => {
     debug: DEBUG,
     log: LOG,
     time: TIME,
-    twofactor_code: TWOFACTOR_CODE,
-    workspace: WORKSPACE,
   } = inputs;
 
   let i = 0; // 再帰でリストの続きから処理するためにインデックスを再帰関数の外に定義する
@@ -31,6 +29,9 @@ const remover = async (inputs) => {
 
     // カスタム絵文字管理画面へ遷移する
     inputs = await goToEmojiPage(browser, page, inputs);
+
+    // 再入力されているかもしれないので取り直す
+    const { twofactor_code: TWOFACTOR_CODE, workspace: WORKSPACE } = inputs;
 
     // ローカルのデコモジが存在しなかったらエラーにして終了する
     if (localDecomojiListLength === 0) {

--- a/scripts/manager/modules/remover.js
+++ b/scripts/manager/modules/remover.js
@@ -30,7 +30,7 @@ const remover = async (inputs) => {
     const page = await browser.newPage();
 
     // カスタム絵文字管理画面へ遷移する
-    inputs = await goToEmojiPage(page, inputs);
+    inputs = await goToEmojiPage(browser, page, inputs);
 
     // ローカルのデコモジが存在しなかったらエラーにして終了する
     if (localDecomojiListLength === 0) {

--- a/scripts/manager/modules/uploader.js
+++ b/scripts/manager/modules/uploader.js
@@ -11,8 +11,6 @@ const uploader = async (inputs) => {
     debug: DEBUG,
     log: LOG,
     time: TIME,
-    twofactor_code: TWOFACTOR_CODE,
-    workspace: WORKSPACE,
   } = inputs;
 
   let i = 0; // 再帰でリストの続きから処理するためにインデックスを再帰関数の外に定義する
@@ -31,6 +29,9 @@ const uploader = async (inputs) => {
 
     // カスタム絵文字管理画面へ遷移する
     inputs = await goToEmojiPage(browser, page, inputs);
+
+    // 再入力されているかもしれないので取り直す
+    const { twofactor_code: TWOFACTOR_CODE, workspace: WORKSPACE } = inputs;
 
     // ローカルのデコモジが存在しなかったらエラーにして終了する
     if (localDecomojiListLength === 0) {

--- a/scripts/manager/modules/uploader.js
+++ b/scripts/manager/modules/uploader.js
@@ -30,7 +30,7 @@ const uploader = async (inputs) => {
     const page = await browser.newPage();
 
     // カスタム絵文字管理画面へ遷移する
-    inputs = await goToEmojiPage(page, inputs);
+    inputs = await goToEmojiPage(browser, page, inputs);
 
     // ローカルのデコモジが存在しなかったらエラーにして終了する
     if (localDecomojiListLength === 0) {


### PR DESCRIPTION
ratelimited エラー後に `TimeoutError: Navigation timeout of 30000 ms exceeded` が出て止まるバグに対応した。

あれこれリファクタを一緒に修正しているが、タイムアウトエラーを引き起こした原因は、おそらくは CAPTCHA が出ているのをうまく拾えていないからだと思われる。

これまではログインエラーが出ている中で CAPTCHA の存在を判定していたのだけど、デバッグしてみるとログインエラーを判定するためのセレクタが変わっていた。なので、まずはそれを修正した。

https://github.com/decomoji/decomoji/compare/master...fix/v5.15.3#diff-f5e1e81e458c9900600c3f54ac32c56bbc703de6d5f06d8c6ca9ce1d413bb09cR39

さらに、場合によってはログインエラー前、すなわちログイン画面に到達した時にすでに CAPTCHA が表示されている場合を確認できたので、その時にもエラーを吐けるように修正した。

https://github.com/decomoji/decomoji/compare/master...fix/v5.15.3#diff-f5e1e81e458c9900600c3f54ac32c56bbc703de6d5f06d8c6ca9ce1d413bb09cR22

というのがこの修正の要点です。あとはリファクタです。