### PR TITLE
add: executablePathの指定

### DIFF
--- a/scripts/manager/modules/pretender.js
+++ b/scripts/manager/modules/pretender.js
@@ -29,6 +29,7 @@ const pretender = async (inputs) => {
   const _pretend = async (inputs) => {
     // puppeteer でブラウザを起動する
     const browser = await puppeteer.launch({
+      executablePath: "/opt/homebrew/bin/chromium",
       devtools: BROWSER,
     });
     // ページを追加する

--- a/scripts/manager/modules/remover.js
+++ b/scripts/manager/modules/remover.js
@@ -30,6 +30,7 @@ const remover = async (inputs) => {
   const _remove = async (inputs) => {
     // puppeteer でブラウザを起動する
     const browser = await puppeteer.launch({
+      executablePath: "/opt/homebrew/bin/chromium",
       devtools: BROWSER,
     });
     // ページを追加する

--- a/scripts/manager/modules/uploader.js
+++ b/scripts/manager/modules/uploader.js
@@ -29,6 +29,7 @@ const uploader = async (inputs) => {
   const _upload = async (inputs) => {
     // puppeteer でブラウザを起動する
     const browser = await puppeteer.launch({
+      executablePath: "/opt/homebrew/bin/chromium",
       devtools: BROWSER,
     });
     // ページを追加する


### PR DESCRIPTION
## 内容
[こちらのissue](https://github.com/decomoji/decomoji/issues/104)解決のためのプルリク

puppeteerをM1のMac環境でも実行可能にするため、該当のファイルに`executablePath`の指定を行いました。

```javascript
    // puppeteer でブラウザを起動する
    const browser = await puppeteer.launch({
      executablePath: "/opt/homebrew/bin/chromium",
      devtools: BROWSER,
    });
```
MacBook Air (M1, 2020)
Mac OS BigSur 11.1で動作確認済み

## 懸念点
他OS、M1以外のMacで実行テストができていないため、その点問題ないか不安です。