### PR TITLE
fix(manager): resultオブジェクトのキーを修正

### DIFF
--- a/scripts/manager/modules/uploader.js
+++ b/scripts/manager/modules/uploader.js
@@ -44,7 +44,7 @@ const uploader = async (inputs) => {
   const result = {
     error: [],
     error_name_taken: [],
-    error_name_taken_18n: [],
+    error_name_taken_i18n: [],
     ok: [],
   };
   const messages = {


### PR DESCRIPTION
`node scripts/manager` により emoji を一括登録しようとしましたが、下記のエラーが発生し止まってしまいました。
コードを確認したところ、ログを記録する `result` オブジェクトのキーが間違ってそうだったので修正しました。
この修正によりエラーが解消されることは確認済です。

```
17014/27685: skipped(international emoji set already includes) osso.
/***/decomoji/scripts/manager/modules/uploader.js:107
        ? result[res.error].push(name)
                            ^

TypeError: Cannot read properties of undefined (reading 'push')
    at _upload (/***/decomoji/scripts/manager/modules/uploader.js:107:29)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async uploader (/***/decomoji/scripts/manager/modules/uploader.js:165:3)
    at async main (/***/decomoji/scripts/manager/index.js:68:7)
```