### PR TITLE
fix(manager): ログイン画面に遷移時のURLを修正

### DIFF
--- a/scripts/manager/modules/goToEmojiPage.js
+++ b/scripts/manager/modules/goToEmojiPage.js
@@ -8,7 +8,7 @@ const goToEmojiPage = async (browser, page, inputs) => {
   TIME && console.time("[Login time]");
   // ログイン画面に遷移する（チームのカスタム絵文字管理画面へのリダイレクトパラメータ付き）
   await page.goto(
-    `https://${inputs.workspace}.slack.com/?redir=%2Fcustomize%2Femoji#/`,
+    `https://${inputs.workspace}.slack.com/sign_in_with_password?redir=%2Fcustomize%2Femoji#/`,
     {
       waitUntil: "domcontentloaded",
     }


### PR DESCRIPTION
# 問題点
正しいワークスペース、パスワード、メールアドレスを入力しても、ワークスペースを再度入力するように促されてしまう。

# 原因
指定遷移先のログインページが`https://${inputs.workspace}.slack.com/?redir=%2Fcustomize%2Femoji#/`の場合、パスワードを用いないマジックコードによる認証でログインが行われるため、await page.type("#password", inputs.password)によるパスワード入力がうまく機能しない。

# 解決策(変更点)

メールアドレスとパスワードによるログインを利用するためにpage.gotoによる遷移を下記のように変更しました。

`https://${inputs.workspace}.slack.com/?redir=%2Fcustomize%2Femoji#/`
↓
`https://${inputs.workspace}.slack.com/sign_in_with_password?redir=%2Fcustomize%2Femoji#/`

これにより、パスワード入力も機能して、ワークスペースが見つからない問題が解消されました。
