### PR TITLE
fix(scripts): waitForNavigationのタイムアウト時間を長めに設定

### DIFF
--- a/scripts/manager/modules/goToEmojiPage.js
+++ b/scripts/manager/modules/goToEmojiPage.js
@@ -32,7 +32,10 @@ const goToEmojiPage = async (browser, page, inputs) => {
   await page.type("#password", inputs.password);
   await Promise.all([
     page.click("#signin_btn"),
-    page.waitForNavigation({ waitUntil: ["load", "networkidle2"] }),
+    page.waitForNavigation({
+      waitUntil: ["load", "networkidle2"],
+      timeout: 60000,
+    }),
   ]);
 
   // ログインエラーになっていたら email と password を再入力させる


### PR DESCRIPTION
大量の絵文字を登録していると、たまに`goToEmojiPage`の実行に時間が掛かってタイムアウトすることがあります。

```
2057/29999: skipped(already exists) bakusyousiyo.
2058/29999: skipped(already exists) bakusyousuru.
2059/29999: skipped(already exists) bakusyoutarou.
2060/29999: ratelimited bakusyouwasure.
Reconnecting...
/Users/yuhei/ghq/github.com/decomoji/decomoji/node_modules/puppeteer/lib/cjs/puppeteer/common/LifecycleWatcher.js:106
        return new Promise((fulfill) => (this._maximumTimer = setTimeout(fulfill, this._timeout))).then(() => new Errors_js_1.TimeoutError(errorMessage));
                                                                                                              ^

TimeoutError: Navigation timeout of 30000 ms exceeded
    at /Users/yuhei/ghq/github.com/decomoji/decomoji/node_modules/puppeteer/lib/cjs/puppeteer/common/LifecycleWatcher.js:106:111
    at async FrameManager.waitForFrameNavigation (/Users/yuhei/ghq/github.com/decomoji/decomoji/node_modules/puppeteer/lib/cjs/puppeteer/common/FrameManager.js:127:23)
    at async Frame.waitForNavigation (/Users/yuhei/ghq/github.com/decomoji/decomoji/node_modules/puppeteer/lib/cjs/puppeteer/common/FrameManager.js:440:16)
    at async Page.waitForNavigation (/Users/yuhei/ghq/github.com/decomoji/decomoji/node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:829:16)
    at async Promise.all (index 1)
    at async goToEmojiPage (/Users/yuhei/ghq/github.com/decomoji/decomoji/scripts/manager/modules/goToEmojiPage.js:33:3)
    at async _upload (/Users/yuhei/ghq/github.com/decomoji/decomoji/scripts/manager/modules/uploader.js:65:14)
    at async _upload (/Users/yuhei/ghq/github.com/decomoji/decomoji/scripts/manager/modules/uploader.js:149:14)
    at async _upload (/Users/yuhei/ghq/github.com/decomoji/decomoji/scripts/manager/modules/uploader.js:149:14)
    at async _upload (/Users/yuhei/ghq/github.com/decomoji/decomoji/scripts/manager/modules/uploader.js:149:14)
>>> elapsed time 17m42s
```

そのため、`page.waitForNavigation`のタイムアウト時間がデフォルトでは30秒に設定されているところを、倍の60秒に変更しました。これによって、手元の環境ではタイムアウトせずに最後まで実行できるようになりました。